### PR TITLE
Release v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ module "public_zone" {
 ```
 
 
+## Resource tagging
+
+This module will add certain tags to specific resources by default. The `tags` variable extends these and adds additional tags to the resources.
+
+| Tags                | Condition                                         | Description            |
+|---------------------|---------------------------------------------------|------------------------|
+| `Name`              | Always on all zones                               | Name of domain         |
+| `Parent`            | On public delegated zones                         | Name of parent domain  |
+| `DelegationSetId`   | On public zones which are using a delegation set  | Name of delegation set |
+| `DelegationSetName` | On public zones which are using a delegation set  | ID of delegation set   |
+
+
 ## Examples
 
 * [private-domains](examples/private-domains)

--- a/README.md
+++ b/README.md
@@ -1,11 +1,21 @@
 # Terraform module: AWS Route53 Zone
 
+**[Usage](#usage)** |
+**[Tagging](#resource-tagging)** |
+**[Importing](#importing-existing-resources)** |
+**[Examples](#examples)** |
+**[Requirements](#requirements)** |
+**[Providers](#providers)** |
+**[Inputs](#inputs)** |
+**[Outputs](#outputs)** |
+**[License](#license)**
+
 [![Build Status](https://travis-ci.org/cytopia/terraform-aws-route53-zone.svg?branch=master)](https://travis-ci.org/cytopia/terraform-aws-route53-zone)
 [![Tag](https://img.shields.io/github/tag/cytopia/terraform-aws-route53-zone.svg)](https://github.com/cytopia/terraform-aws-route53-zone/releases)
 [![Terraform](https://img.shields.io/badge/Terraform--registry-aws--route53--zone-brightgreen.svg)](https://registry.terraform.io/modules/cytopia/route53-zone/aws/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](https://opensource.org/licenses/MIT)
 
-This Terraform module is able to create **delegation sets**, **public** and **private** hosted zones for root and delegated domains.
+This Terraform module is able to create an arbitrary number of **delegation sets**, **public** and **private** hosted zones for root and delegated domains.
 
 **Public** hosted zones can be created with or without a delegation set.
 **Private** hosted zones will always have the default VPC from the current region attached, but can optionally also attach more VPCs from any region.
@@ -144,6 +154,7 @@ No requirements.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
+
 ## Example output
 
 ```bash
@@ -240,9 +251,11 @@ public_delegated_secondary_zones = {
   }
 ```
 
+
 ## Authors
 
 Module managed by [cytopia](https://github.com/cytopia).
+
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,36 @@ This module will add certain tags to specific resources by default. The `tags` v
 | `DelegationSetName` | On public zones which are using a delegation set  | ID of delegation set   |
 
 
+## Importing existing resources
+
+In case you have existing resources and want to import them into this module, use the following commands:
+
+### Delegation sets
+```bash
+# List available delegation sets
+aws route53 list-reusable-delegation-sets
+
+# Define them in tfvars
+delegation_sets = [
+  "",  # <- If a delegation set is nameless, use an empty string
+  "deleg1",
+]
+
+# Import them
+terraform import 'aws_route53_delegation_set.delegation_sets[""]' <DELEG-ID>
+terraform import 'aws_route53_delegation_set.delegation_sets["deleg1"]' <DELEG-ID>
+```
+
+### Zones
+```bash
+# Public root zone
+terraform import 'aws_route53_zone.public_root_zones["www.example.com"]' <ZONE-ID>
+
+# Private root zone
+terraform import 'aws_route53_zone.private_root_zones["private.example.com"]' <ZONE-ID>
+```
+
+
 ## Examples
 
 * [private-domains](examples/private-domains)

--- a/locals.tf
+++ b/locals.tf
@@ -26,14 +26,14 @@ locals {
   #   "example2.tld" {
   #     "name" = "example2.tld"
   #     "deleg_id" = null
-  #     "deleg_name" = ""
+  #     "deleg_name" = null
   #   },
   # }
   public_root_zones = {
     for zone in var.public_root_zones : zone.name => {
       name       = zone.name
       deleg_id   = zone.delegation_set != null ? aws_route53_delegation_set.delegation_sets[zone.delegation_set]["id"] : null
-      deleg_name = zone.delegation_set != null ? zone.delegation_set : ""
+      deleg_name = zone.delegation_set
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,6 @@ resource "aws_route53_record" "public_delegated_secondary_ns_records" {
   name    = each.value.name
   type    = "NS"
   ttl     = each.value.ns_ttl
-
   records = each.value.ns_list
 
   depends_on = [aws_route53_zone.public_delegated_secondary_zones]


### PR DESCRIPTION
# Release v1.1.1

### Fixes
* Do not add a `DelegationSetName` tag with empty value to a zone which does not have a delegation set. (Delegation set names can also be empty if they have no name and this might be confusing)

### Adds
* Add documentation about how default tagging works
* Add documentation about how to import existing resources into this module 

## Test
```bash
  # aws_route53_zone.public_root_zones["iwww.example.net"] will be updated in-place
  ~ resource "aws_route53_zone" "public_root_zones" {
        comment       = "Managed by Terraform"
        force_destroy = false
        id            = "YYYYYYYYYYYY"
        name          = "www.example.net."
        name_servers  = [
            "ns-xxx.awsdns-xx.tld",
            "ns-xxx.awsdns-xx.tld",
            "ns-xxx.awsdns-xx.tld",
            "ns-xxx.awsdns-xx.tld",
        ]
      ~ tags          = {
          - "DelegationSetName" = "" -> null
            "Department"        = "devops"
            "Environment"       = "playground"
            "Name"              = "www.example.net"
        }
        zone_id       = "XXXXXXXXXXXXX"
```